### PR TITLE
서치바 디자인 수정

### DIFF
--- a/Projects/Feature/Scenes/SearchScene/Component/SearchbarCustom.swift
+++ b/Projects/Feature/Scenes/SearchScene/Component/SearchbarCustom.swift
@@ -22,17 +22,17 @@ struct SearchBar: View {
     HStack {
       TextField("아티스트를 검색하세요", text: $text)
         .autocorrectionDisabled(true)
-        .padding(12.5)
-        .padding(.horizontal, 20)
+        .padding(7)
+        .padding(.horizontal, 34)
         .foregroundColor(.fontGrey2)
         .background(Color.mainGrey1)
-        .cornerRadius(20)
+        .cornerRadius(10)
         .overlay(
           HStack {
             Image(systemName: "magnifyingglass")
               .foregroundColor(.fontGrey2)
               .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
-              .padding(.leading, 7.5)
+              .padding(.leading, 16)
             
             if isEditing && text.count != 0 {
               Button {

--- a/Projects/Feature/Scenes/SearchScene/View/SearchView.swift
+++ b/Projects/Feature/Scenes/SearchScene/View/SearchView.swift
@@ -48,8 +48,9 @@ struct SearchView: View {
 //      MainView().logo
 //        .padding([.leading, .vertical], 10)
       SearchBar(text: $viewModel.searchText, isEditing: $viewModel.searchIsPresented)
-        .id(ScrollID.searchBar)
+//        .id(ScrollID.searchBar)
     }
+//    .searchable(text: $viewModel.searchText, placement: .toolbar, prompt: "아티스트를 검색하세오")
     .padding(.top)
   }
   


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #116 

👷 **작업한 내용**
- **기본 컴포넌트 대신** 머스크의 서치 바 디자인 수정...

## 🚨 참고 사항
- 기본 컴포넌트를 사용하려 했으나, 위치 고정이 안돼서 커스텀으로... 하기로 했습니다 (placement: .toolbar 해도 원하는 위치로 안됨...)
- 사실 기본 컴포넌트로 바꾸는 것도 머스크가 다 해주셨어여 제가 한 건 브랜치와 이슈 만들기밖에 없었어요^^

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|수정|![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team12-Creative8/assets/127755029/093120ba-bfea-4ffa-ac06-7742c3f0835f)|

## 📟 관련 이슈
- Resolved: #
