### PR TITLE
#209/update archive view UI - 보관함 뷰 수정

### DIFF
--- a/Projects/Feature/Feature.xcodeproj/project.pbxproj
+++ b/Projects/Feature/Feature.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		6EA0587A8956D298CD666573 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CAF19513FC0FC8E2BBF031 /* MainViewModel.swift */; };
 		720A765913530AA37CFF00B4 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F2F8F05B58D59460428D7A /* TabBarView.swift */; };
 		7611BAD555C16F6A7E0CEA5C /* ArtistImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD79847FF98BCA9A4C8CCAF /* ArtistImage.swift */; };
-		7895A841E262B3C4586F6BDC /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811EED38EE073FA6E9252D7F /* MainView.swift */; }
+		7895A841E262B3C4586F6BDC /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811EED38EE073FA6E9252D7F /* MainView.swift */; };
 		802686A7E7B66DD12F44A9A9 /* SetlistFMLinkButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493DEF5A3CB257D50F23D1F6 /* SetlistFMLinkButtonView.swift */; };
 		900EC881930541C98C607D30 /* SearchArtistList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB796CBAC6A2C6DB4ACE654E /* SearchArtistList.swift */; };
 		94BB809B61709B35B36F7BA3 /* ExportPlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20D00D9D84D120E91EDCF4E /* ExportPlaylistViewModel.swift */; };
@@ -111,7 +111,6 @@
 		7391501B4523A254694E36D3 /* ConcertInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcertInfoView.swift; sourceTree = "<group>"; };
 		75E35BB3B227839591945A42 /* BookmarkedSetlistsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkedSetlistsView.swift; sourceTree = "<group>"; };
 		777E319B5E5F3B22C401257A /* IsEmptyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsEmptyCell.swift; sourceTree = "<group>"; };
-    
 		7A919947E4A82878ABA33FDF /* CustomTitleAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTitleAlert.swift; sourceTree = "<group>"; };
 		8083107765017313EF49CE3A /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		80859AB1C625F8E5EC6CCD1C /* EmptyMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyMainView.swift; sourceTree = "<group>"; };
@@ -311,7 +310,6 @@
 		6DC82FD44AFA8E6846CC19FE = {
 			isa = PBXGroup;
 			children = (
-
 				C05AC50F60B178F60E99048B /* Project */,
 				FF84802DBECE1160D2AE52BE /* Frameworks */,
 				F37C3A4FE623C846745B9CE2 /* Products */,
@@ -557,7 +555,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Projects/Feature/Scenes/ArchiveScene/Component/ArchiveArtistCell.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/Component/ArchiveArtistCell.swift
@@ -23,6 +23,7 @@ struct ArchiveArtistCell: View {
           ProgressView()
         }
       } else {
+        // TODO: 이미지 변경?
         if colorScheme == .light {
           Image(uiImage: UIImage(named: "whiteTicket", in: Bundle(identifier: "com.creative8.seta.UI"), compatibleWith: nil)!)
             .centerCropped()

--- a/Projects/Feature/Scenes/ArchiveScene/Component/ArchiveConcertInfoCell.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/Component/ArchiveConcertInfoCell.swift
@@ -57,8 +57,9 @@ struct ArchiveConcertInfoCell: View {
       NavigationLink(value: NavigationDelivery(setlistId: info.setlist.setlistId, artistInfo: SaveArtistInfo(name: info.artistInfo.name, country: "", alias: "", mbid: info.artistInfo.mbid, gid: 0, imageUrl: "", songList: []))) {
         HStack {
           VStack(alignment: .leading) {
+            // TODO: 색 변경
             Text(DateFormatter.dateFormatter().string(from: info.setlist.date))
-              .padding(3)
+              .padding(EdgeInsets(top: 3, leading: 7, bottom: 3, trailing: 7))
               .font(.caption)
               .background(Capsule().foregroundStyle(Color.mainOrange))
             Text(info.artistInfo.name).font(.subheadline).bold().foregroundStyle(Color.mainBlack)
@@ -67,7 +68,6 @@ struct ArchiveConcertInfoCell: View {
           }
           .lineLimit(1)
           .padding(.vertical)
-//          .padding(.bottom, 20)
           Spacer()
         }
       }
@@ -96,6 +96,7 @@ struct ArchiveConcertInfoCell: View {
           ProgressView()
         }
       } else {
+        // TODO: 이미지 변경?
         if colorScheme == .light {
           Image(uiImage: UIImage(named: "whiteTicket", in: Bundle(identifier: "com.creative8.seta.UI"), compatibleWith: nil)!)
             .centerCropped()

--- a/Projects/Feature/Scenes/ArchiveScene/Component/ArchiveConcertInfoCell.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/Component/ArchiveConcertInfoCell.swift
@@ -13,47 +13,108 @@ import UI
 struct ArchiveConcertInfoCell: View {
   @Binding var selectedTab: Tab
   let info: ArchivedConcertInfo
+  let url: URL?
   let dataServiece = SetlistDataService()
   @StateObject var dataManager = SwiftDataManager()
   @Environment(\.modelContext) var modelContext
+  @Environment(\.colorScheme) var colorScheme
   
   var body: some View {
+    ZStack {
+      imageBG
+      VStack {
+        menuBar
+        Spacer()
+        infoBlock
+      }
+      .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+    .onAppear { dataManager.modelContext = modelContext }
+  }
+  
+  private var menuBar: some View {
     HStack {
-      NavigationLink(value: NavigationDelivery(setlistId: info.setlist.setlistId, artistInfo: SaveArtistInfo(name: info.artistInfo.name, country: "", alias: "", mbid: info.artistInfo.mbid, gid: 0, imageUrl: "", songList: []))) {
-          VStack {
-            Text(DateFormatter.yearFormatter().string(from: info.setlist.date)).foregroundStyle(Color.fontGrey25).tracking(0.5)
-            Text(DateFormatter.dateMonthFormatter().string(from: info.setlist.date)).foregroundStyle(Color.mainBlack)
-          }
-          .font(.headline)
-          Spacer()
-            .frame(width: UIWidth * 0.08)
-          VStack(alignment: .leading) {
-            Text(info.artistInfo.name).font(.subheadline).foregroundStyle(Color.mainBlack)
-            Text(info.setlist.venue).font(.footnote).foregroundStyle(Color.mainBlack)
-          }
-          .lineLimit(1)
-          .frame(width: UIWidth * 0.5, alignment: .leading)
-          .padding(.vertical, 10)
-        }
-      
       Spacer()
-      
       Menu {
         NavigationLink(value: NavigationDelivery(artistInfo: SaveArtistInfo(name: info.artistInfo.name, country: "", alias: info.artistInfo.alias, mbid: info.artistInfo.mbid, gid: 0, imageUrl: "", songList: []))) {
           Text("아티스트 보기")
         }
         NavigationLink(value: NavigationDelivery(setlistId: info.setlist.setlistId, artistInfo: SaveArtistInfo(name: info.artistInfo.name, country: "", alias: info.artistInfo.alias, mbid: info.artistInfo.mbid, gid: 0, imageUrl: "", songList: []))) {
-            Text("세트리스트 보기")
-          }
+          Text("세트리스트 보기")
+        }
         Button("공연 북마크 취소") { dataManager.deleteArchivedConcertInfo(info) }
       } label: {
         Image(systemName: "ellipsis")
           .font(.title3)
-          .foregroundStyle(Color.mainBlack)
+          .foregroundStyle(Color.mainWhite)
           .padding()
       }
     }
-    .padding(.horizontal, 24)
-    .onAppear { dataManager.modelContext = modelContext }
+  }
+  
+  private var infoBlock: some View {
+    VStack(alignment: .leading) {
+      NavigationLink(value: NavigationDelivery(setlistId: info.setlist.setlistId, artistInfo: SaveArtistInfo(name: info.artistInfo.name, country: "", alias: "", mbid: info.artistInfo.mbid, gid: 0, imageUrl: "", songList: []))) {
+        HStack {
+          VStack(alignment: .leading) {
+            Text(DateFormatter.dateFormatter().string(from: info.setlist.date))
+              .padding(3)
+              .font(.caption)
+              .background(Capsule().foregroundStyle(Color.mainOrange))
+            Text(info.artistInfo.name).font(.subheadline).bold().foregroundStyle(Color.mainBlack)
+              .padding(.vertical, 8)
+            Text(info.setlist.venue).font(.footnote).foregroundStyle(Color.mainBlack)
+          }
+          .lineLimit(1)
+          .padding(.vertical)
+//          .padding(.bottom, 20)
+          Spacer()
+        }
+      }
+      .padding(.horizontal, 10)
+      .background(
+        Rectangle()
+          .frame(width: UIWidth*0.43)
+          .foregroundStyle(Color.mainWhite)
+      )
+    }
+  }
+  
+  @ViewBuilder
+  private var imageBG: some View {
+    Group {
+      if let url = url {
+        AsyncImage(url: url) { image in
+          image
+            .centerCropped()
+            .overlay(
+              RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.mainGrey1, lineWidth: 1)
+                .foregroundStyle(Color.clear)
+            )
+        } placeholder: {
+          ProgressView()
+        }
+      } else {
+        if colorScheme == .light {
+          Image(uiImage: UIImage(named: "whiteTicket", in: Bundle(identifier: "com.creative8.seta.UI"), compatibleWith: nil)!)
+            .centerCropped()
+            .overlay(
+              RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.mainGrey1, lineWidth: 1) // 색상과 선 두께를 원하는 대로 설정
+            )
+        } else {
+          Image(uiImage: UIImage(named: "darkTicket", in: Bundle(identifier: "com.creative8.seta.UI"), compatibleWith: nil)!)
+            .centerCropped()
+            .overlay(
+              RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.mainGrey1, lineWidth: 1) // 색상과 선 두께를 원하는 대로 설정
+            )
+        }
+      }
+    }
+    .aspectRatio(1.0, contentMode: .fit)
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+    
   }
 }

--- a/Projects/Feature/Scenes/ArchiveScene/Component/ArtistSetCell.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/Component/ArtistSetCell.swift
@@ -17,17 +17,15 @@ struct ArtistSetCell: View {
   
   var body: some View {
     HStack {
-      Group {
         artistImg
         Text(name)
           .font(.subheadline)
           .foregroundStyle(isSelected ? Color.settingTextBoxWhite : Color.fontGrey2)
-      }
-      .padding(6)
     }
+    .padding(6)
     .background {
       let color = isSelected ? Color.mainBlack : Color.mainGrey1
-      color.clipShape(RoundedRectangle(cornerRadius: 8))
+      color.clipShape(RoundedRectangle(cornerRadius: 12))
     }
   }
   

--- a/Projects/Feature/Scenes/ArchiveScene/Component/ArtistSetCell.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/Component/ArtistSetCell.swift
@@ -10,34 +10,51 @@ import SwiftUI
 import UI
 
 struct ArtistSetCell: View {
-   let name: String
-   let isSelected: Bool
-   var body: some View {
-     Text(name)
-       .foregroundStyle(isSelected ? Color.settingTextBoxWhite : Color.fontGrey2)
-       .padding(10)
-       .background {
-         let color = isSelected ? Color.mainBlack : Color.mainGrey1
-         color.clipShape(RoundedRectangle(cornerRadius: 12))
-       }
-       .font(.subheadline)
-   }
- }
+  //	 let artistUrl: URL?
+  let name: String
+  let artistImgUrl: String?
+  let isSelected: Bool
+  var body: some View {
+    HStack {
+      Text(name)
+        .foregroundStyle(isSelected ? Color.settingTextBoxWhite : Color.fontGrey2)
+        .padding(10)
+        .font(.subheadline)
+      if let url = artistImgUrl {
+        AsyncImage(url: URL(string: artistImgUrl!)) { image in
+          image
+            .centerCropped()
+            .overlay(
+              RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.mainGrey1, lineWidth: 1)
+                .foregroundStyle(Color.clear)
+            )
+        } placeholder: {
+          ProgressView()
+        }
+      }
+    }
+    .background {
+      let color = isSelected ? Color.mainBlack : Color.mainGrey1
+      color.clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+  }
+}
 
 struct AllArtistsSetCell: View {
-   let name: LocalizedStringResource
-   let isSelected: Bool
-   var body: some View {
-     Text(name)
-       .foregroundStyle(isSelected ? Color.settingTextBoxWhite : Color.fontGrey2)
-       .padding(10)
-       .background {
-         let color = isSelected ? Color.mainBlack : Color.mainGrey1
-         color.clipShape(RoundedRectangle(cornerRadius: 12))
-       }
-   }
- }
-
- #Preview {
-   ArtistSetCell(name: "방탄소년단", isSelected: false)
- }
+  let name: LocalizedStringResource
+  let isSelected: Bool
+  var body: some View {
+    Text(name)
+      .foregroundStyle(isSelected ? Color.settingTextBoxWhite : Color.fontGrey2)
+      .padding(10)
+      .background {
+        let color = isSelected ? Color.mainBlack : Color.mainGrey1
+        color.clipShape(RoundedRectangle(cornerRadius: 12))
+      }
+  }
+}
+//
+// #Preview {
+//		ArtistSetCell(name: "방탄소년단", isSelected: false)
+// }

--- a/Projects/Feature/Scenes/ArchiveScene/Component/ArtistSetCell.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/Component/ArtistSetCell.swift
@@ -10,34 +10,62 @@ import SwiftUI
 import UI
 
 struct ArtistSetCell: View {
-  //	 let artistUrl: URL?
   let name: String
-  let artistImgUrl: String?
+  let artistImgUrl: URL?
   let isSelected: Bool
+  @Environment(\.colorScheme) var colorScheme
+  
   var body: some View {
     HStack {
-      Text(name)
-        .foregroundStyle(isSelected ? Color.settingTextBoxWhite : Color.fontGrey2)
-        .padding(10)
-        .font(.subheadline)
+      Group {
+        artistImg
+        Text(name)
+          .font(.subheadline)
+          .foregroundStyle(isSelected ? Color.settingTextBoxWhite : Color.fontGrey2)
+      }
+      .padding(6)
+    }
+    .background {
+      let color = isSelected ? Color.mainBlack : Color.mainGrey1
+      color.clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+  }
+  
+  @ViewBuilder
+  private var artistImg: some View {
+    Group {
       if let url = artistImgUrl {
-        AsyncImage(url: URL(string: artistImgUrl!)) { image in
+        AsyncImage(url: url) { image in
           image
             .centerCropped()
             .overlay(
-              RoundedRectangle(cornerRadius: 12)
+              RoundedRectangle(cornerRadius: 8)
                 .stroke(Color.mainGrey1, lineWidth: 1)
                 .foregroundStyle(Color.clear)
             )
         } placeholder: {
           ProgressView()
         }
+      } else {
+        if colorScheme == .light {
+          Image(uiImage: UIImage(named: "whiteTicket", in: Bundle(identifier: "com.creative8.seta.UI"), compatibleWith: nil)!)
+            .centerCropped()
+            .overlay(
+              RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.mainGrey1, lineWidth: 1) // 색상과 선 두께를 원하는 대로 설정
+            )
+        } else {
+          Image(uiImage: UIImage(named: "darkTicket", in: Bundle(identifier: "com.creative8.seta.UI"), compatibleWith: nil)!)
+            .centerCropped()
+            .overlay(
+              RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.mainGrey1, lineWidth: 1) // 색상과 선 두께를 원하는 대로 설정
+            )
+        }
       }
     }
-    .background {
-      let color = isSelected ? Color.mainBlack : Color.mainGrey1
-      color.clipShape(RoundedRectangle(cornerRadius: 12))
-    }
+    .aspectRatio(1.0, contentMode: .fit)
+    .clipShape(RoundedRectangle(cornerRadius: 8))
   }
 }
 

--- a/Projects/Feature/Scenes/ArchiveScene/View/ArchivingView.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/View/ArchivingView.swift
@@ -23,16 +23,9 @@ struct ArchivingView: View {
   var body: some View {
     NavigationStack(path: $tabViewManager.pageStack) {
       VStack {
-        //        segmentedButtonsView
-        //          .padding(.horizontal)
-        //          .padding(.vertical)
-        //        if viewModel.selectSegment == .bookmark {
-        //          bookmarkView
-        //        } else {
-        //          artistView
-        //        }
         bookmarkView
       }
+      // TODO: 색 변경
       .background(Color.gray)
       .navigationTitle("보관함")
       .navigationDestination(for: NavigationDelivery.self) { value in
@@ -59,23 +52,6 @@ struct ArchivingView: View {
 }
 
 extension ArchivingView {
-  //  private var segmentedButtonsView: some View {
-  //    HStack {
-  //      Button("북마크한 공연") {
-  //        viewModel.selectSegment = .bookmark
-  //      }
-  //      .foregroundStyle(viewModel.selectSegment == .bookmark ? Color.mainBlack : Color.fontGrey3)
-  //
-  //      Button("찜한 아티스트") {
-  //        viewModel.selectSegment = .likeArtist
-  //      }
-  //      .foregroundStyle(viewModel.selectSegment == .bookmark ? Color.fontGrey3 : Color.mainBlack)
-  //      .padding(.horizontal)
-  //    }
-  //    .font(.headline)
-  //    .frame(maxWidth: .infinity, alignment: .leading)
-  //    .padding(.top)
-  //  }
   private var bookmarkView: some View {
     Group {
       if concertInfo.isEmpty {
@@ -121,7 +97,7 @@ extension ArchivingView {
                 viewModel.selectArtist = artist
               }
             } label: {
-              ArtistSetCell(name: artist, artistImgUrl: findArtistImageURL(byName: artist), isSelected: viewModel.selectArtist.contains(artist))
+              ArtistSetCell(name: artist, artistImgUrl: URL(string: findArtistImageURL(byName: artist) ?? ""), isSelected: viewModel.selectArtist.contains(artist))
             }
           }
         }
@@ -148,76 +124,74 @@ extension ArchivingView {
     }
   }
   
-  private var artistView: some View {
-    Group {
-      if likeArtists.isEmpty {
-        IsEmptyCell(type: .likeArtist)
-      } else {
-        ScrollViewReader { proxy in
-          List {
-            VStack(alignment: .leading, spacing: 0) {
-              Text("찜한 아티스트 중 상단의 5명이 메인화면에 등장합니다")
-                .font(.footnote)
-                .foregroundStyle(Color.fontGrey2)
-                .padding(.top)
-                .listRowBackground(Color.backgroundWhite)
-              Group {
-                Text("변경을 원하신다면 ")
-                  .font(.footnote)
-                  .foregroundStyle(Color.fontGrey2)
-                +
-                Text("아티스트를 꾹 눌러 순서를 옮겨보세요")
-                  .font(.footnote)
-                  .fontWeight(.semibold)
-                  .foregroundStyle(Color.fontGrey2)
-              }
-            }.id(topID)
-              .listRowSeparator(.hidden)
-              .listRowBackground(Color.backgroundWhite)
-            
-            artistListView
-              .listRowSeparator(.hidden)
-              .listRowBackground(Color.backgroundWhite)
-          }
-          .scrollIndicators(.hidden)
-          .listStyle(.plain)
-          .padding(EdgeInsets(top: -10, leading: -18, bottom: 10, trailing: -18))
-          .onReceive(tabViewManager.$scrollToTop) { _ in
-            withAnimation {
-              proxy.scrollTo(topID)
-            }
-          }
-        }
-      }
-    }
-    .padding(.horizontal, 24)
-  }
+//  private var artistView: some View {
+//    Group {
+//      if likeArtists.isEmpty {
+//        IsEmptyCell(type: .likeArtist)
+//      } else {
+//        ScrollViewReader { proxy in
+//          List {
+//            VStack(alignment: .leading, spacing: 0) {
+//              Text("찜한 아티스트 중 상단의 5명이 메인화면에 등장합니다")
+//                .font(.footnote)
+//                .foregroundStyle(Color.fontGrey2)
+//                .padding(.top)
+//                .listRowBackground(Color.backgroundWhite)
+//              Group {
+//                Text("변경을 원하신다면 ")
+//                  .font(.footnote)
+//                  .foregroundStyle(Color.fontGrey2)
+//                +
+//                Text("아티스트를 꾹 눌러 순서를 옮겨보세요")
+//                  .font(.footnote)
+//                  .fontWeight(.semibold)
+//                  .foregroundStyle(Color.fontGrey2)
+//              }
+//            }.id(topID)
+//              .listRowSeparator(.hidden)
+//              .listRowBackground(Color.backgroundWhite)
+//            
+//            artistListView
+//              .listRowSeparator(.hidden)
+//              .listRowBackground(Color.backgroundWhite)
+//          }
+//          .scrollIndicators(.hidden)
+//          .listStyle(.plain)
+//          .padding(EdgeInsets(top: -10, leading: -18, bottom: 10, trailing: -18))
+//          .onReceive(tabViewManager.$scrollToTop) { _ in
+//            withAnimation {
+//              proxy.scrollTo(topID)
+//            }
+//          }
+//        }
+//      }
+//    }
+//    .padding(.horizontal, 24)
+//  }
   
-  private var artistListView: some View {
-    ForEach(Array(likeArtists.enumerated()), id: \.element) { index, item in
-      HStack {
-        ArchiveArtistCell(artistUrl: URL(string: item.artistInfo.imageUrl), isNewUpdate: false)
-        Text("\(item.artistInfo.name)")
-          .font(.subheadline)
-          .foregroundStyle(index < 5 ? Color.mainOrange : Color.mainBlack)
-          .background(
-            NavigationLink(value: NavigationDelivery(artistInfo: SaveArtistInfo(name: item.artistInfo.name, country: "", alias: item.artistInfo.alias, mbid: item.artistInfo.mbid, gid: 0, imageUrl: "", songList: []))) {
-              Text("")
-            }
-              .opacity(0)
-          )
-        Spacer()
-        MenuButton(selectedTab: $selectedTab, item: item)
-      }
-    }
-    .onMove { source, destination in
-      var updatedItems = likeArtists
-      updatedItems.move(fromOffsets: source, toOffset: destination)
-      for (index, item) in updatedItems.enumerated() {
-        item.orderIndex = likeArtists.count - 1 - index
-      }
-    }
-  }
+//  private var artistListView: some View {
+//    ForEach(Array(likeArtists.enumerated()), id: \.element) { index, item in
+//      HStack {
+//        ArchiveArtistCell(artistUrl: URL(string: item.artistInfo.imageUrl), isNewUpdate: false)
+//        Text("\(item.artistInfo.name)")
+//          .font(.subheadline)
+//          .foregroundStyle(index < 5 ? Color.mainOrange : Color.mainBlack)
+//          .background(
+//            NavigationLink(value: NavigationDelivery(artistInfo: SaveArtistInfo(name: item.artistInfo.name, country: "", alias: item.artistInfo.alias, mbid: item.artistInfo.mbid, gid: 0, imageUrl: "", songList: []))) {
+//              Text("")
+//            }
+//              .opacity(0)
+//          )
+//        Spacer()
+//        MenuButton(selectedTab: $selectedTab, item: item)
+//      }
+//    }
+//    .onMove { source, destination in
+//      var updatedItems = likeArtists
+//      updatedItems.move(fromOffsets: source, toOffset: destination)
+//      for (index, item) in updatedItems.enumerated() {
+//        item.orderIndex = likeArtists.count - 1 - index
+//      }
+//    }
+//  }
 }
-
-

--- a/Projects/Feature/Scenes/ArchiveScene/View/ArchivingView.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/View/ArchivingView.swift
@@ -73,8 +73,12 @@ extension ArchivingView {
     }
   }
   
-  private func findArtistImageURL(byName name: String) -> String? {
-      return likeArtists.first { $0.artistInfo.name.localizedStandardContains(name) }?.artistInfo.imageUrl
+  private func findArtistImageURL(byName name: String) -> String {
+    if let url = likeArtists.first(where: { $0.artistInfo.name.localizedStandardContains(name) })?.artistInfo.imageUrl {
+      return url
+    } else {
+      return ""
+    }
   }
   
   private var bookmarkListView: some View {
@@ -97,7 +101,7 @@ extension ArchivingView {
                 viewModel.selectArtist = artist
               }
             } label: {
-              ArtistSetCell(name: artist, artistImgUrl: URL(string: findArtistImageURL(byName: artist) ?? ""), isSelected: viewModel.selectArtist.contains(artist))
+              ArtistSetCell(name: artist, artistImgUrl: URL(string: findArtistImageURL(byName: artist)), isSelected: viewModel.selectArtist.contains(artist))
             }
           }
         }

--- a/Projects/Feature/Scenes/ArchiveScene/View/ArchivingView.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/View/ArchivingView.swift
@@ -23,16 +23,17 @@ struct ArchivingView: View {
   var body: some View {
     NavigationStack(path: $tabViewManager.pageStack) {
       VStack {
-        segmentedButtonsView
-          .padding(.horizontal)
-          .padding(.vertical)
-        if viewModel.selectSegment == .bookmark {
-          bookmarkView
-        } else {
-          artistView
-        }
+        //        segmentedButtonsView
+        //          .padding(.horizontal)
+        //          .padding(.vertical)
+        //        if viewModel.selectSegment == .bookmark {
+        //          bookmarkView
+        //        } else {
+        //          artistView
+        //        }
+        bookmarkView
       }
-      .background(Color.backgroundWhite)
+      .background(Color.gray)
       .navigationTitle("보관함")
       .navigationDestination(for: NavigationDelivery.self) { value in
         if value.setlistId != nil {
@@ -58,24 +59,23 @@ struct ArchivingView: View {
 }
 
 extension ArchivingView {
-  private var segmentedButtonsView: some View {
-    HStack {
-      Button("북마크한 공연") {
-        viewModel.selectSegment = .bookmark
-      }
-      .foregroundStyle(viewModel.selectSegment == .bookmark ? Color.mainBlack : Color.fontGrey3)
-
-      Button("찜한 아티스트") {
-        viewModel.selectSegment = .likeArtist
-      }
-      .foregroundStyle(viewModel.selectSegment == .bookmark ? Color.fontGrey3 : Color.mainBlack)
-      .padding(.horizontal)
-    }
-    .font(.headline)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(.top)
-  }
-  
+  //  private var segmentedButtonsView: some View {
+  //    HStack {
+  //      Button("북마크한 공연") {
+  //        viewModel.selectSegment = .bookmark
+  //      }
+  //      .foregroundStyle(viewModel.selectSegment == .bookmark ? Color.mainBlack : Color.fontGrey3)
+  //
+  //      Button("찜한 아티스트") {
+  //        viewModel.selectSegment = .likeArtist
+  //      }
+  //      .foregroundStyle(viewModel.selectSegment == .bookmark ? Color.fontGrey3 : Color.mainBlack)
+  //      .padding(.horizontal)
+  //    }
+  //    .font(.headline)
+  //    .frame(maxWidth: .infinity, alignment: .leading)
+  //    .padding(.top)
+  //  }
   private var bookmarkView: some View {
     Group {
       if concertInfo.isEmpty {
@@ -95,6 +95,10 @@ extension ArchivingView {
         }
       }
     }
+  }
+  
+  private func findArtistImageURL(byName name: String) -> String? {
+      return likeArtists.first { $0.artistInfo.name.localizedStandardContains(name) }?.artistInfo.imageUrl
   }
   
   private var bookmarkListView: some View {
@@ -117,7 +121,7 @@ extension ArchivingView {
                 viewModel.selectArtist = artist
               }
             } label: {
-              ArtistSetCell(name: artist, isSelected: viewModel.selectArtist.contains(artist))
+              ArtistSetCell(name: artist, artistImgUrl: findArtistImageURL(byName: artist), isSelected: viewModel.selectArtist.contains(artist))
             }
           }
         }
@@ -125,14 +129,18 @@ extension ArchivingView {
       .scrollIndicators(.hidden)
       .padding(.vertical)
       
-      ForEach(concertInfo) { item in
-        if viewModel.selectArtist.isEmpty || viewModel.selectArtist.contains(item.artistInfo.name) {
-          ArchiveConcertInfoCell(selectedTab: $selectedTab, info: item)
-          Divider()
-            .foregroundStyle(Color.lineGrey1)
-            .padding(.horizontal, UIWidth * 0.049)
+      LazyVGrid(columns: [
+        GridItem(.flexible(), spacing: 8, alignment: nil),
+        GridItem(.flexible(), spacing: 8, alignment: nil)
+      ], spacing: 16) {
+        ForEach(concertInfo) { item in
+          if viewModel.selectArtist.isEmpty || viewModel.selectArtist.contains(item.artistInfo.name) {
+            ArchiveConcertInfoCell(selectedTab: $selectedTab, info: item, url: URL(string: item.artistInfo.imageUrl))
+              .frame(width: UIWidth * 0.43)
+          }
         }
       }
+      .padding(.horizontal, 24)
     }
     .onAppear { viewModel.insertArtistSet(concertInfo) }
     .onChange(of: concertInfo) { _, newValue in
@@ -196,7 +204,7 @@ extension ArchivingView {
             NavigationLink(value: NavigationDelivery(artistInfo: SaveArtistInfo(name: item.artistInfo.name, country: "", alias: item.artistInfo.alias, mbid: item.artistInfo.mbid, gid: 0, imageUrl: "", songList: []))) {
               Text("")
             }
-            .opacity(0)
+              .opacity(0)
           )
         Spacer()
         MenuButton(selectedTab: $selectedTab, item: item)

--- a/Projects/UI/Sources/Extensions/DateFormatterExtension.swift
+++ b/Projects/UI/Sources/Extensions/DateFormatterExtension.swift
@@ -21,4 +21,11 @@ public extension DateFormatter {
       formatter.dateFormat = "YYYY"
       return formatter
   }
+  
+  static func dateFormatter() -> DateFormatter {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "ko_KR")
+    formatter.dateFormat = "YYYY년 MM월dd일"
+    return formatter
+  }
 }


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #209 

👷 **작업한 내용**
- 보관함 뷰 UI 수정

## 🚨 참고 사항
- 아티스트 이름 버튼(상단 버튼)에 이미지를 넣을 때 바로 가져올 수 있는 방법을 못찾아서 이렇게 찾아오게 했는데 더 좋은 방법 아시면 알려주세요...
이걸로 찾아오니까 이무진씨를 못찾던데 챗지피티가 만들어준거라 잘 모르겠어요😩
```
private func findArtistImageURL(byName name: String) -> String? {
      return likeArtists.first { $0.artistInfo.name.localizedStandardContains(name) }?.artistInfo.imageUrl
  }
```
- 색상 변경할 부분은 주석 달아뒀습니다.
- 화면에서 안 보이는 부분은 삭제하거나 주석 처리 해뒀습니다. 나머지도 지워도 되면 삭제하고 다시 커밋하겠습니다!!
- 헉... 메인 풀받는걸 깜빡했습니다
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|UI 변경|<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team12-Creative8/assets/127755029/8b96d0a9-195a-46d9-bcfe-5948c48d8951" width = 300>|

## 📟 관련 이슈
- Resolved: #
