### PR TITLE
#235/ MainView QA 및 애플뮤직 속도 개선

### DIFF
--- a/Projects/Core/Sources/Service/AppleMusicService.swift
+++ b/Projects/Core/Sources/Service/AppleMusicService.swift
@@ -65,7 +65,7 @@ public final class AppleMusicService: MusicPlaylistAddable, Sendable {
             let songsToAdd = sortedResults.compactMap { $0.1?.songs.first }
 
             // 플레이리스트 생성 및 곡 추가를 더 빠르게 처리
-            let newPlayList = try await MusicLibrary.shared.createPlaylist(
+            let _ = try await MusicLibrary.shared.createPlaylist(
                 name: name,
                 description: "Seta에서 생성된 플레이리스트 입니다.",
                 authorDisplayName: venue,

--- a/Projects/Core/Sources/Service/AppleMusicService.swift
+++ b/Projects/Core/Sources/Service/AppleMusicService.swift
@@ -9,80 +9,114 @@
 import Foundation
 import MusicKit
 import StoreKit
+import Combine
 
 public final class AppleMusicService: MusicPlaylistAddable, Sendable {
-  public var id: MusicItemID = ""
-  
-  public init() {
-  }
-  
-  // 플레이리스트 추가 및 음악 목록 추가
-  public func addPlayList(name: String, musicList: [(String, String?)], venue: String?) {
-    Task {
-      // musicList를 index가 들어간 튜플로 변환
-      let indexedMusicList = musicList.enumerated().map { (index, music) in
-        (index, music)
-      }
-      // index 순서대로 정렬
-      let sortedMusicList = indexedMusicList.sorted { $0.0 < $1.0 }.map { $0.1 }
-      
-      let newPlayList = try await MusicLibrary.shared.createPlaylist(name: String(name), description: "Seta에서 생성된 플레이리스트 입니다.", authorDisplayName: String(venue ?? ""))
-      
-      for music in sortedMusicList {
-        // MusicCatalogSearchRequest를 비동기로 처리
-        let response = try await searchMusic(title: String(music.0), singer: music.1 ?? "")
-        
-        if let song = response.songs.first {
-          // 순차적으로 MusicLibrary에 추가
-          try await MusicLibrary.shared.add(song, to: newPlayList)
+    public var id: MusicItemID = ""
+    
+    public init() {
+    }
+    
+    actor SearchResultsManager {
+        private var results: [(Int, MusicCatalogSearchResponse?)] = []
+
+        func append(_ result: (Int, MusicCatalogSearchResponse?)) {
+            results.append(result)
         }
-      }
+
+        func getSortedResults() -> [(Int, MusicCatalogSearchResponse?)] {
+            return results.sorted { $0.0 < $1.0 }
+        }
     }
-  }
-  
-  // MusicCatalogSearchRequest를 비동기로 처리하는 함수
-  private func searchMusic(title: String, singer: String) async throws -> MusicCatalogSearchResponse {
-    var request = MusicCatalogSearchRequest.init(term: "\(singer) \(title)", types: [MusicKit.Song.self])
-    request.includeTopResults = true
-    let response = try await request.response()
-    return response
-  }
-  
-  public func requestMusicAuthorization() {
-    SKCloudServiceController.requestAuthorization { [weak self] status in
-      switch status {
-      case .authorized:
-        print("Apple Music authorized")
-      case .restricted:
-        print("Apple Music authorization restricted")
-      case .notDetermined:
-        print("Apple Music authorization not determined")
-      case .denied:
-        print("Apple Music authorization denied")
-      @unknown default:
-        print("")
-      }
+
+    public func addPlayList(name: String, musicList: [(String, String?)], venue: String?) {
+        let searchResultsManager = SearchResultsManager()
+
+        Task {
+            // musicList를 index가 들어간 튜플로 변환
+            let indexedMusicList = musicList.enumerated().map { (index, music) in
+                (index, music)
+            }
+
+            // 모든 음악을 비동기로 검색
+            await withTaskGroup(of: Void.self) { group in
+                for (index, music) in indexedMusicList {
+                    group.addTask {
+
+                        do {
+                            let response = try await self.searchMusic(title: music.0, singer: music.1 ?? "")
+                                                        
+                            // actor를 통해 안전하게 searchResults에 추가
+                            await searchResultsManager.append((index, response))
+                        } catch {
+                            print("Error searching for '\(music.0)': \(error)")
+                            
+                            // 실패한 경우에도 인덱스를 유지
+                            await searchResultsManager.append((index, nil))
+                        }
+                    }
+                }
+            }
+
+            // 검색 결과를 인덱스 순서대로 정렬
+            let sortedResults = await searchResultsManager.getSortedResults()
+
+            // 유효한 곡만 필터링하여 배열로 변환
+            let songsToAdd = sortedResults.compactMap { $0.1?.songs.first }
+
+            // 플레이리스트 생성 및 곡 추가를 더 빠르게 처리
+            let newPlayList = try await MusicLibrary.shared.createPlaylist(
+                name: name,
+                description: "Seta에서 생성된 플레이리스트 입니다.",
+                authorDisplayName: venue,
+                items: songsToAdd
+            )
+        }
     }
-  }
-  
+
+    // MusicCatalogSearchRequest를 비동기로 처리하는 함수
+    private func searchMusic(title: String, singer: String) async throws -> MusicCatalogSearchResponse {
+        var request = MusicCatalogSearchRequest(term: "\(singer) \(title)", types: [MusicKit.Song.self])
+        request.includeTopResults = true
+        let response = try await request.response()
+        return response
+    }
+    
+    public func requestMusicAuthorization() {
+        SKCloudServiceController.requestAuthorization { [weak self] status in
+            switch status {
+            case .authorized:
+                print("Apple Music authorized")
+            case .restricted:
+                print("Apple Music authorization restricted")
+            case .notDetermined:
+                print("Apple Music authorization not determined")
+            case .denied:
+                print("Apple Music authorization denied")
+            @unknown default:
+                print("")
+            }
+        }
+    }
+    
 }
 
 public final class CheckAppleMusicSubscription: ObservableObject {
-  @Published var check: Bool = false
-  public static let shared: CheckAppleMusicSubscription = CheckAppleMusicSubscription()
-  // 사용자가 애플 뮤직을 구독 중인지 확인
-  public init() {
-  }
-  
-  public func appleMusicSubscription(completion: @escaping (Bool) -> Void) {
-    SKCloudServiceController().requestCapabilities { (capability: SKCloudServiceCapability, err: Error?) in
-      guard err == nil else { return }
-      if capability.contains(SKCloudServiceCapability.musicCatalogPlayback) {
-        self.check = true
-      } else if capability.contains(SKCloudServiceCapability.musicCatalogSubscriptionEligible) {
-        self.check = false
-      }
-      completion(self.check)
+    @Published var check: Bool = false
+    public static let shared: CheckAppleMusicSubscription = CheckAppleMusicSubscription()
+    // 사용자가 애플 뮤직을 구독 중인지 확인
+    public init() {
     }
-  }
+    
+    public func appleMusicSubscription(completion: @escaping (Bool) -> Void) {
+        SKCloudServiceController().requestCapabilities { (capability: SKCloudServiceCapability, err: Error?) in
+            guard err == nil else { return }
+            if capability.contains(SKCloudServiceCapability.musicCatalogPlayback) {
+                self.check = true
+            } else if capability.contains(SKCloudServiceCapability.musicCatalogSubscriptionEligible) {
+                self.check = false
+            }
+            completion(self.check)
+        }
+    }
 }

--- a/Projects/Feature/Project.swift
+++ b/Projects/Feature/Project.swift
@@ -12,12 +12,12 @@ let project = Project.makeModule(
     name: "Feature",
     product: .framework,
     packages: [
-        .Marquee,
+        .MarqueeText,
     ],
     dependencies: [
         .project(target: "Core", path: .relativeToRoot("Projects/Core")),
         .project(target: "UI", path: .relativeToRoot("Projects/UI")),
-        .SPM.Marquee,
+        .SPM.MarqueeText,
     ],
     sources: ["Scenes/**"]
 )

--- a/Projects/Feature/Scenes/ArchiveScene/View/ArchivingArtistView.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/View/ArchivingArtistView.swift
@@ -25,7 +25,7 @@ struct ArchivingArtistView: View {
         Text("찜한 아티스트")
           .font(.title).bold()
           .foregroundStyle(Color.mainBlack)
-          .padding(.vertical)
+          .padding(.vertical, 12)
           .frame(alignment: .leading)
         Spacer()
       }
@@ -37,7 +37,7 @@ struct ArchivingArtistView: View {
             Text("상단 5명의 아티스트만 홈 화면에 표시됩니다\n변경을 원하신다면 순서를 옮겨보세요")
               .font(.footnote)
               .foregroundStyle(Color.gray)
-              .padding(.bottom)
+              .padding(.bottom, 16)
             
           }.id(topID)
             .listRowSeparator(.hidden)

--- a/Projects/Feature/Scenes/ArchiveScene/View/ArchivingArtistView.swift
+++ b/Projects/Feature/Scenes/ArchiveScene/View/ArchivingArtistView.swift
@@ -20,24 +20,23 @@ struct ArchivingArtistView: View {
   @Namespace var topID
   
   var body: some View {
-    Group {
       HStack {
         Text("찜한 아티스트")
           .font(.title).bold()
           .foregroundStyle(Color.mainBlack)
-          .padding(.vertical, 12)
-          .frame(alignment: .leading)
+          .padding([.leading, .top], 23)
         Spacer()
       }
+      .padding(.bottom, -5)
       if likeArtists.isEmpty {
         IsEmptyCell(type: .likeArtist)
       } else {
         List {
-          VStack(alignment: .leading, spacing: 0) {
+          VStack(alignment: .leading) {
             Text("상단 5명의 아티스트만 홈 화면에 표시됩니다\n변경을 원하신다면 순서를 옮겨보세요")
               .font(.footnote)
               .foregroundStyle(Color.gray)
-              .padding(.bottom, 16)
+              .padding(.bottom, 6)
             
           }.id(topID)
             .listRowSeparator(.hidden)
@@ -46,14 +45,14 @@ struct ArchivingArtistView: View {
           archiveArtistListCell
             .listRowSeparator(.hidden)
             .listRowBackground(Color.mainWhite)
+            Spacer().frame(height: 30)
         }
+        .padding(.horizontal, 5)
         .scrollIndicators(.hidden)
         .listStyle(.plain)
-        .padding(EdgeInsets(top: -10, leading: -18, bottom: 10, trailing: -18))
         
       }
-    }
-    .padding(.horizontal, 24)
+    
   }
   
   private var archiveArtistListCell: some View {
@@ -77,12 +76,11 @@ struct ArchivingArtistView: View {
       var updatedItems = likeArtists
       updatedItems.move(fromOffsets: source, toOffset: destination)
       
-      // Update CoreData context and save changes
       for (index, item) in updatedItems.enumerated() {
         item.orderIndex = likeArtists.count - 1 - index
       }
-      // Assuming `modelContext` is available
-      do {
+
+        do {
         try modelContext.save()
       } catch {
         print("Failed to save context: \(error)")

--- a/Projects/Feature/Scenes/ArtistScene/View/ArtistInfoView.swift
+++ b/Projects/Feature/Scenes/ArtistScene/View/ArtistInfoView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SwiftData
 import Core
 import UI
-import Marquee
+import MarqueeText
 
 struct ArtistInfoView: View {
   @ObservedObject var vm: ArtistViewModel
@@ -82,12 +82,11 @@ struct ArtistInfoView: View {
   private var nameLayer: some View {
     HStack(spacing: 0) {
       if textWidth > parentWidth {
-        Marquee {
-          Text(vm.artistInfo.name)
-            .fixedSize(horizontal: true, vertical: false)
-        }
-        .marqueeDuration(5.0)
-        .frame(width: parentWidth)
+          MarqueeText(text: vm.artistInfo.name,
+                      font: .systemFont(ofSize: 20, weight: .semibold),
+                      leftFade: 16,
+                      rightFade: 16,
+                      startDelay: 0.3)
       } else {
         Text(vm.artistInfo.name)
           .frame(width: UIWidth * 0.8, alignment: .leading)

--- a/Projects/Feature/Scenes/MainScene/Component/ArtistImage.swift
+++ b/Projects/Feature/Scenes/MainScene/Component/ArtistImage.swift
@@ -33,9 +33,11 @@ struct ArtistImage: View {
           artistEmptyImage
         }
       }
-      .frame(width: UIWidth * 0.81, height: UIWidth * 0.81)
+      .frame(height: UIHeight * 0.38)
       .clipShape(RoundedRectangle(cornerRadius: 15))
       .clipped()
+      .safeAreaPadding(.horizontal, UIWidth * 0.07)
+      
     }
   }
   

--- a/Projects/Feature/Scenes/MainScene/Component/ArtistMainSetlistView.swift
+++ b/Projects/Feature/Scenes/MainScene/Component/ArtistMainSetlistView.swift
@@ -90,9 +90,11 @@ struct ArtistMainSetlistView: View {
                 ListRowView(index: song.tape == true ? nil : index + 1, title: song.name ?? "")
                     .opacity(song.tape == true ? 0.6 : 1.0)
                     .padding(.vertical, 7)
-
-                if index + 1 < (isExpanded ? displaySongs.count : 3) {
-                    Divider()
+                
+                if displaySongs.count > 1 {
+                    if index + 1 < (isExpanded ? displaySongs.count : 3) {
+                        Divider()
+                    }
                 }
             }
         }

--- a/Projects/Feature/Scenes/MainScene/Component/ArtistMainSetlistView.swift
+++ b/Projects/Feature/Scenes/MainScene/Component/ArtistMainSetlistView.swift
@@ -27,8 +27,10 @@ struct ArtistMainSetlistView: View {
             headerView
             Spacer().frame(height: 25)
             setlistContent
+                .padding(.bottom, 25)
             if displaySongs.count > 3 {
                 footerView
+                    .padding(.bottom, 5)
             }
         }
         .font(.footnote)
@@ -89,7 +91,7 @@ struct ArtistMainSetlistView: View {
             ForEach(Array(displaySongs.prefix(isExpanded ? displaySongs.count : 3).enumerated()), id: \.offset) { index, song in
                 ListRowView(index: song.tape == true ? nil : index + 1, title: song.name ?? "")
                     .opacity(song.tape == true ? 0.6 : 1.0)
-                    .padding(.vertical, 7)
+                    .padding(3)
                 
                 if displaySongs.count > 1 {
                     if index + 1 < (isExpanded ? displaySongs.count : 3) {

--- a/Projects/Feature/Scenes/MainScene/Component/ArtistNameView.swift
+++ b/Projects/Feature/Scenes/MainScene/Component/ArtistNameView.swift
@@ -36,6 +36,7 @@ struct ArtistNameView: View {
           .frame(width: UIWidth * 0.8, alignment: .center)
       }
     }
+    .frame(width: UIWidth * 0.8, height: UIHeight * 0.07)
     .foregroundColor(viewModel.selectedIndex == index ? Color.mainBlack : Color.gray)
     .background(
       GeometryReader { geo in
@@ -59,4 +60,3 @@ struct ArtistNameView: View {
     textWidth = controller.view.intrinsicContentSize.width
   }
 }
-

--- a/Projects/Feature/Scenes/MainScene/Component/ArtistNameView.swift
+++ b/Projects/Feature/Scenes/MainScene/Component/ArtistNameView.swift
@@ -7,56 +7,56 @@
 //
 
 import SwiftUI
-import Marquee
+import MarqueeText
 
 struct ArtistNameView: View {
-  @Binding var selectedTab: Tab
-  @ObservedObject var viewModel: MainViewModel
-  var index: Int
-  var name: String
-  @State private var textWidth: CGFloat = 0
-  @State private var parentWidth: CGFloat = 0
-  
-  var body: some View {
-    HStack(spacing: 0) {
-      if textWidth > parentWidth {
-        Marquee {
-          Text(name)
+    @Binding var selectedTab: Tab
+    @ObservedObject var viewModel: MainViewModel
+    var index: Int
+    var name: String
+    @State private var textWidth: CGFloat = 0
+    @State private var parentWidth: CGFloat = 0
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            if textWidth > parentWidth {
+                MarqueeText(
+                    text: name,
+                    font: .systemFont(ofSize: 32, weight: .semibold),
+                    leftFade: 16,
+                    rightFade: 16,
+                    startDelay: 3
+                )
+                .frame(width: parentWidth)
+            } else {
+                Text(name)
+                    .font(.title)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .frame(width: UIWidth * 0.8, alignment: .center)
+            }
+        }
+        .frame(width: UIWidth * 0.8, height: UIHeight * 0.06)
+        .foregroundColor(viewModel.selectedIndex == index ? Color.mainBlack : Color.gray)
+        .background(
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear {
+                        parentWidth = geo.size.width
+                        measureTextWidth()
+                    }
+            }
+        )
+    }
+    
+    private func measureTextWidth() {
+        let text = Text(name)
             .font(.title)
             .fontWeight(.semibold)
-            .fixedSize(horizontal: true, vertical: false) 
-        }
-        .marqueeDuration(5.0)
-        .frame(width: parentWidth)
-      } else {
-        Text(name)
-          .font(.title)
-          .fontWeight(.semibold)
-          .lineLimit(1)
-          .frame(width: UIWidth * 0.8, alignment: .center)
-      }
+        
+        let controller = UIHostingController(rootView: text)
+        controller.view.frame.size = .zero
+        controller.view.sizeToFit()
+        textWidth = controller.view.intrinsicContentSize.width
     }
-    .frame(width: UIWidth * 0.8, height: UIHeight * 0.07)
-    .foregroundColor(viewModel.selectedIndex == index ? Color.mainBlack : Color.gray)
-    .background(
-      GeometryReader { geo in
-        Color.clear
-          .onAppear {
-            parentWidth = geo.size.width
-            measureTextWidth()
-          }
-      }
-    )
-  }
-  
-  private func measureTextWidth() {
-    let text = Text(name)
-      .font(.title)
-      .fontWeight(.semibold)
-    
-    let controller = UIHostingController(rootView: text)
-    controller.view.frame.size = .zero
-    controller.view.sizeToFit()
-    textWidth = controller.view.intrinsicContentSize.width
-  }
 }

--- a/Projects/Feature/Scenes/MainScene/Component/ArtistsContentView.swift
+++ b/Projects/Feature/Scenes/MainScene/Component/ArtistsContentView.swift
@@ -10,92 +10,74 @@ import Core
 import SwiftData
 
 struct ArtistsContentView: View {
-  @Binding var selectedTab: Tab
-  @StateObject var viewModel: MainViewModel
-  @State var artistInfo: SaveArtistInfo
-  @StateObject var dataManager = SwiftDataManager()
-  @Environment(\.modelContext) var modelContext
-  @Query(sort: \LikeArtist.orderIndex, order: .reverse) var likeArtists: [LikeArtist]
-  @StateObject var tabViewManager: TabViewManager
-
-  var index: Int
-  
-  var body: some View {
-    NavigationStack(path: $tabViewManager.pageStack) {
-      VStack(spacing: 24) {
-        
-        if viewModel.isLoading {
-          loadingView
-        } else {
-          contentView
-        }
-        
-        navigationLink
-      }
-      .onAppear {
-        dataManager.modelContext = modelContext
-      }
-    }
-  }
-  
-  private var loadingView: some View {
-    ProgressView()
-  }
-  
-  private var navigationLink: some View {
-    NavigationLink(destination: ArtistView(
-      selectedTab: $selectedTab,
-      artistName: artistInfo.name,
-      artistAlias: artistInfo.alias,
-      artistMbid: artistInfo.mbid
-    ), isActive: $viewModel.navigateToArtistView) {
-      EmptyView()
-    }
-  }
-  
-  private var contentView: some View {
-    let setlists: [Setlist?] = viewModel.setlists[index] ?? []
+    @Binding var selectedTab: Tab
+    @StateObject var viewModel: MainViewModel
+    @State var artistInfo: SaveArtistInfo
+    @StateObject var dataManager = SwiftDataManager()
+    @Environment(\.modelContext) var modelContext
+    @Query(sort: \LikeArtist.orderIndex, order: .reverse) var likeArtists: [LikeArtist]
+    @StateObject var tabViewManager: TabViewManager
     
-    if let firstSetlist = setlists.compactMap({ $0 }).first {
-      return AnyView(
-        VStack(spacing: 12) {
-          summarizedSetlistView(for: firstSetlist)
-          ArtistMainSetlistView(viewModel: viewModel, index: index)
-        }
-      )
-    } else {
-      return AnyView(emptySetlistView)
-    }
-  }
-  
-  private var emptySetlistView: some View {
-    SummarizedSetlistInfoView(
-      type: .recentConcert,
-      info: nil,
-      infoButtonAction: nil,
-      chevronButtonAction: nil
-    )
-  }
-  
-  private func summarizedSetlistView(for setlist: Setlist) -> some View {
-    let venueName = setlist.venue?.name ?? ""
-    let city = setlist.venue?.city?.name ?? ""
-    let countryName = setlist.venue?.city?.country?.name ?? ""
-    let artistName = setlist.artist?.name ?? ""
+    var index: Int
     
-    return SummarizedSetlistInfoView(
-      type: .recentConcert,
-      info: SetlistInfo(
-        artistInfo: artistInfo.toArtistInfo(),
-        id: setlist.id ?? "",
-        date: viewModel.getDateFormatted(dateString: setlist.eventDate ?? ""),
-        title: setlist.tour?.name ?? "\(artistName) Setlist",
-        venue: "\(venueName)\n\(city), \(countryName)"
-      ),
-      infoButtonAction: nil,
-      chevronButtonAction: {
-        viewModel.navigateToArtistView = true
-      }
-    )
-  }
+    var body: some View {
+        let setlists: [Setlist?] = viewModel.setlists[index] ?? []
+        
+        NavigationStack(path: $tabViewManager.pageStack) {
+            VStack(spacing: 24) {
+                
+                if viewModel.isLoading {
+                    loadingView
+                } else {
+                    if let firstSetlist = setlists.compactMap({ $0 }).first {
+                            VStack(spacing: 12) {
+                                summarizedSetlistView(for: firstSetlist)
+                                ArtistMainSetlistView(viewModel: viewModel, index: index)
+                            }
+                                            
+                    } else {
+                        emptySetlistView
+                    }
+                }
+            }
+            .onAppear {
+                dataManager.modelContext = modelContext
+            }
+        }
+    }
+    
+    private var loadingView: some View {
+        ProgressView()
+    }
+    
+    private var emptySetlistView: some View {
+        SummarizedSetlistInfoView(
+            type: .recentConcert,
+            info: nil,
+            infoButtonAction: nil,
+            chevronButtonAction: nil
+        )
+    }
+    
+    private func summarizedSetlistView(for setlist: Setlist) -> some View {
+        let venueName = setlist.venue?.name ?? ""
+        let city = setlist.venue?.city?.name ?? ""
+        let countryName = setlist.venue?.city?.country?.name ?? ""
+        let artistName = setlist.artist?.name ?? ""
+        
+        return SummarizedSetlistInfoView(
+            type: .recentConcert,
+            info: SetlistInfo(
+                artistInfo: artistInfo.toArtistInfo(),
+                id: setlist.id ?? "",
+                date: viewModel.getDateFormatted(dateString: setlist.eventDate ?? ""),
+                title: setlist.tour?.name ?? "\(artistName) Setlist",
+                venue: "\(venueName)\n\(city), \(countryName)"
+            ),
+            infoButtonAction: nil,
+            chevronButtonAction: {
+                viewModel.navigateToArtistView = true
+            }
+        )
+    }
 }

--- a/Projects/Feature/Scenes/MainScene/Component/EmptyMainView.swift
+++ b/Projects/Feature/Scenes/MainScene/Component/EmptyMainView.swift
@@ -13,44 +13,29 @@ import Core
 import UI
 
 struct EmptyMainView: View {
-  @Binding var selectedTab: Tab
-  
-  var body: some View {
-    ZStack {
-      Color.mainWhite
-      VStack {
-        Spacer()
-        Text("찜한 아티스트가 없습니다")
-          .font(.callout)
-          .padding(.bottom)
-          .foregroundStyle(Color.mainBlack)
-        Group {
-          VStack {
-            Text("관심있는 아티스트 정보를 빠르게")
-            Text("확인하고 싶으시다면 찜을 해주세요")
-          }
+    @Binding var selectedTab: Tab
+    
+    var body: some View {
+        ZStack {
+            Color.mainWhite.ignoresSafeArea()
+            VStack {
+                Spacer()
+                Text("찜한 아티스트가 없어요")
+                    .font(.system(size: 16, weight: .semibold))
+                    .padding(.bottom, 9)
+                    .foregroundStyle(Color.mainBlack)
+                Group {
+                    VStack {
+                        Text("검색에서 원하는 아티스트를 찾고")
+                        Text("하트버튼을 눌러주세요")
+                    }
+                    .foregroundStyle(Color.gray)
+                }
+                .font(.system(size: 13, weight: .regular))
+                .multilineTextAlignment(.center)
+                .padding(.bottom)
+                Spacer()
+            }
         }
-        .font(.footnote)
-        .multilineTextAlignment(.center)
-        .foregroundStyle(Color.black850)
-        .padding(.bottom)
-        Button {
-          selectedTab = .search
-        } label: {
-          HStack {
-            Text("아티스트 찜하러 가기")
-            Image(systemName: "magnifyingglass")
-          }
-          .bold()
-          .foregroundStyle(Color.mainWhite)
-          .font(.system(size: 14))
-          .padding(EdgeInsets(top: 17, leading: 22, bottom: 17, trailing: 22))
-          .background(RoundedRectangle(cornerRadius: 14)
-            .foregroundStyle(Color.black850))
-        }
-        .padding(.vertical)
-        Spacer()
-      }
     }
-  }
 }

--- a/Projects/Feature/Scenes/MainScene/Component/MainToolTipView.swift
+++ b/Projects/Feature/Scenes/MainScene/Component/MainToolTipView.swift
@@ -14,10 +14,11 @@ struct MainTooltipView: View {
       CustomTriangleShape()
         .fill(Color.mainOrange)
         .offset(x: -50, y: 3)
-        .frame(width: 20, height: 20)
+        .frame(width: 20, height: 50)
       
       CustomRectangleShape(text: "메인화면 아티스트를 수정할 수 있어요")
         .frame(width: 250, height: 40)
+
     }
   }
 }
@@ -74,8 +75,8 @@ private struct CustomRectangleShape: View {
             Text(text)
                 .font(.footnote)
                 .foregroundColor(.white)
-                .padding(.vertical, 8)
-                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .padding(.horizontal, 18)
                 .background(
                     RoundedRectangle(cornerRadius: 12)
                         .fill(Color.mainOrange)

--- a/Projects/Feature/Scenes/MainScene/View/MainView.swift
+++ b/Projects/Feature/Scenes/MainScene/View/MainView.swift
@@ -101,7 +101,7 @@ struct MainView: View {
         .padding(.vertical, 16)
         .background(
             RoundedRectangle(cornerRadius: 76)
-                .foregroundStyle(Color.gray6))
+                .foregroundStyle(Color.gray6.opacity(0.6)))
         
     }
     
@@ -142,7 +142,6 @@ struct MainView: View {
                         }
                     }
                     .frame(height: UIHeight * 0.45)
-                    
                     // 아티스트 세트리스트
                     ArtistsContentView(selectedTab: $selectedTab,
                                        viewModel: viewModel,

--- a/Projects/Feature/Scenes/MainScene/ViewModel/MainViewModel.swift
+++ b/Projects/Feature/Scenes/MainScene/ViewModel/MainViewModel.swift
@@ -16,7 +16,6 @@ final class MainViewModel: ObservableObject {
   let koreanConverter = KoreanConverter()
   
   @Published var selectedIndex: Int = 0
-  @Published var scrollToIndex: Int = 0
   @Published var isTapped: Bool = false
   @Published var isLoading: Bool = false
   @Published var pageStack: [NavigationDelivery] = []
@@ -98,28 +97,6 @@ final class MainViewModel: ObservableObject {
         idx -= 1
       }
     }
-  }
-  func resetScroll() {
-    scrollToIndex = 0
-    selectedIndex = 0
-
-  }
-  
-  func selectArtist(index: Int) {
-    selectedIndex = index
-    scrollToIndex = index
-  }
-  
-  func scrollToSelectedIndex(proxy: ScrollViewProxy) {
-    withAnimation {
-      proxy.scrollTo(scrollToIndex, anchor: .center)
-    }
-  }
-  
-  func resetScrollToIndex(proxy: ScrollViewProxy, likeArtists: [LikeArtist]) {
-    selectedIndex = 0
-    scrollToIndex = 0
-    scrollToSelectedIndex(proxy: proxy)
   }
   
   func navigationDestination(for value: NavigationDelivery) -> some View {

--- a/Projects/Feature/Scenes/SetlistScene/Component/CustomTitleAlert.swift
+++ b/Projects/Feature/Scenes/SetlistScene/Component/CustomTitleAlert.swift
@@ -32,17 +32,15 @@ struct CustomTitleAlert: View {
     VStack(spacing: 0) {
       titleView
       textFieldView
-        .padding(.vertical, 24)
+        .padding(24)
+        Divider()
       buttonsView
     }
-    .padding(.horizontal, 24)
     .padding(.top, 32)
-    .padding(.bottom, 13)
     .background(Color.mainWhite)
     .cornerRadius(12)
   }
   
-  @ViewBuilder
   private var titleView: some View {
       Text("플레이리스트 제목")
       .foregroundColor(Color.mainBlack)
@@ -59,15 +57,15 @@ struct CustomTitleAlert: View {
     )
     .padding(.horizontal)
     .padding(.vertical, 7)
-    .background(RoundedRectangle(cornerRadius: 10).fill(Color.gray6).stroke(Color(UIColor.systemGray)))
+    .background(RoundedRectangle(cornerRadius: 10).fill(Color.gray.opacity(0.2)).stroke(Color(UIColor.systemGray)))
   }
   
   private var buttonsView: some View {
-    VStack(spacing: 0) {
-        primaryButtonView
+    HStack(spacing: 0) {
       if let dismissButton = dismissButton {
         dismissButtonView
       }
+        primaryButtonView
     }
   }
   
@@ -84,8 +82,7 @@ struct CustomTitleAlert: View {
           button.action?()
         }
       }
-      .foregroundColor(Color.mainWhite)
-      .background(RoundedRectangle(cornerRadius: 14).foregroundStyle(Color.mainOrange))
+      .foregroundColor(Color.mainOrange)
     }
   }
   
@@ -98,7 +95,7 @@ struct CustomTitleAlert: View {
         }
       }
       .foregroundColor(Color.mainBlack)
-      .background(RoundedRectangle(cornerRadius: 14).foregroundStyle(Color.mainWhite))
+      .background(RoundedRectangle(cornerRadius: 14).foregroundStyle(Color.clear))
     }
   }
   

--- a/Projects/Feature/Scenes/SetlistScene/Component/CustomTitleAlert.swift
+++ b/Projects/Feature/Scenes/SetlistScene/Component/CustomTitleAlert.swift
@@ -23,7 +23,7 @@ struct CustomTitleAlert: View {
   @ObservedObject var exportViewModel: ExportPlaylistViewModel
   
   var body: some View {
-    ZStack {
+      ZStack(alignment: .center) {
       alertView
     }
     .ignoresSafeArea()
@@ -157,7 +157,7 @@ struct CustomAlertModifier {
 extension CustomAlertModifier: ViewModifier {
   
   func body(content: Content) -> some View {
-    ZStack {
+      ZStack(alignment: .top) {
       content
       if isPresented {
         // 얼럿이 띄워질 때 반투명한 뒷 배경을 추가
@@ -171,6 +171,7 @@ extension CustomAlertModifier: ViewModifier {
           dismissButton: dismissButton,
           primaryButton: primaryButton, exportViewModel: exportViewModel)
         .padding(.horizontal, 20)
+        .padding(.top, UIScreen.main.bounds.height * 0.25)
         .zIndex(1) // 얼럿 창이 뒷 배경보다 위에 나타나도록 설정
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden)

--- a/Projects/Feature/Scenes/SetlistScene/Component/ExportPlaylistButtonView.swift
+++ b/Projects/Feature/Scenes/SetlistScene/Component/ExportPlaylistButtonView.swift
@@ -11,148 +11,161 @@ import Core
 import UI
 
 struct ExportPlaylistButtonView: View {
-  let setlist: Setlist?
-  let artistInfo: ArtistInfo?
-  @ObservedObject var vm: SetlistViewModel
-  @Binding var showToastMessageAppleMusic: Bool
-  @Binding var showToastMessageCapture: Bool
-  @Binding var showToastMessageSubscription: Bool
-  @Binding var showSpotifyAlert: Bool
-  @Binding var showCaptureAlert: Bool
-  @ObservedObject var exportViewModel: ExportPlaylistViewModel
-  
-  private func toastMessageToShow() -> LocalizedStringResource? {
-    if showToastMessageAppleMusic {
-      return "1~2분 후 Apple Music에서 확인하세요"
-    } else if showToastMessageCapture {
-      return "캡쳐된 이미지를 앨범에서 확인하세요"
-    } else if showToastMessageSubscription {
-      return "플레이리스트를 내보내려면 Apple Music을 구독해야 합니다"
-    } else if showSpotifyAlert {
-      return "10초 뒤 Spotify에서 확인하세요"
-    } else {
-      return nil
-    }
-  }
-  
-  var body: some View {
-    ZStack {
-      VStack(spacing: 0) {
-        Spacer()
-        
-        Text("플레이리스트 만들기")
-          .foregroundStyle(Color.mainWhite)
-          .font(.callout)
-          .fontWeight(.semibold)
-          .frame(maxWidth: .infinity)
-          .padding(.vertical, 16)
-          .background(Color.mainBlack)
-          .cornerRadius(14)
-          .padding(.horizontal, 30)
-          .padding(.bottom, 50)
-          .background(Rectangle().foregroundStyle(Color.gray6))
-          .onTapGesture {
-            vm.createArrayForExportPlaylist(setlist: setlist, songList: artistInfo?.songList ?? [], artistName: artistInfo?.name)
-            vm.showModal.toggle()
-          }
-        
-      }
-      
-      if showSpotifyAlert {
-        VStack {
-          ToastMessageView(
-            message: "Spotify로 세트리스트가 옮겨지고 있어요!",
-            subMessage: "15초 후 완료 예정",
-            icon: "dot.radiowaves.left.and.right",
-            color: Color.toast1
-          )
-          .padding(.horizontal, UIWidth * 0.075)
-          .padding(.top, 5)
-          Spacer()
+    let setlist: Setlist?
+    let artistInfo: ArtistInfo?
+    @ObservedObject var vm: SetlistViewModel
+    @Binding var showToastMessageAppleMusic: Bool
+    @Binding var showToastMessageCapture: Bool
+    @Binding var showToastMessageSubscription: Bool
+    @Binding var showSpotifyAlert: Bool
+    @Binding var showCaptureAlert: Bool
+    @ObservedObject var exportViewModel: ExportPlaylistViewModel
+    
+    private func toastMessageToShow() -> LocalizedStringResource? {
+        if showToastMessageAppleMusic {
+            return "10초 뒤 Apple Music에서 확인하세요"
+        } else if showToastMessageCapture {
+            return "캡쳐된 이미지를 앨범에서 확인하세요"
+        } else if showToastMessageSubscription {
+            return "플레이리스트를 내보내려면 Apple Music을 구독해야 합니다"
+        } else if showSpotifyAlert {
+            return "10초 뒤 Spotify에서 확인하세요"
+        } else {
+            return nil
         }
-      }
-      
-      if showCaptureAlert {
+    }
+    
+    var body: some View {
         ZStack {
-          Color.black.opacity(0.6).ignoresSafeArea()
-          captureSetlistAlertView
-            .padding(.bottom, 120)
-        }
-      }
-      
-      if showToastMessageCapture {
-        VStack {
-          ToastMessageView(
-            message: "캡쳐된 이미지를 앨범에서 확인하세요",
-            subMessage: nil,
-            icon: "checkmark.circle.fill",
-            color: Color.toast1
-          )
-          .padding(.horizontal, UIWidth * 0.075)
-          .padding(.top, 5)
-          Spacer()
-        }
-      }
-      
-    }
-    .sheet(isPresented: $vm.showModal) {
-      BottomModalView(setlist: setlist, artistInfo: artistInfo, exportViewModel: exportViewModel, vm: vm, showToastMessageAppleMusic: $showToastMessageAppleMusic, showCaptureALert: $showCaptureAlert, showSpotifyAlert: $showSpotifyAlert)
-        .presentationDetents([.fraction(0.4)])
-        .presentationDragIndicator(.visible)
-    }
-  }
-  
-  private var captureSetlistAlertView: some View {
-    ZStack {
-      RoundedRectangle(cornerRadius: 12.0)
-        .frame(width: UIWidth * 0.95, height: UIHeight * 0.23)
-        .foregroundStyle(Color.white)
-      VStack {
-        Text("Bugs, FLO, genie, VIBE를 이용하시나요?")
-          .font(.callout.bold())
-          .padding()
-        Text("위의 뮤직앱에서는 이미지로 된 세트리스트를\n인식해 플레이리스트로 변환합니다.\n원하는 세트리스트를 이미지로 받아보세요.")
-          .multilineTextAlignment(.center)
-          .font(.footnote)
-          .foregroundStyle(Color.gray)
-        Divider()
-          .padding(.vertical, 15)
-        HStack {
-          Button {
-            showCaptureAlert = false
-          } label: {
-            Text("취소")
-              .frame(width: UIWidth * 0.95 * 0.5)
-              .font(.callout)
-              .foregroundStyle(Color.black)
-              .padding(.bottom)
-          }
-          Button {
-            exportViewModel.handlePhotoExportButtonAction()
-            if !exportViewModel.checkPhotoPermission() {
-              takeSetlistToImage(vm.setlistSongKoreanName)
+            VStack(spacing: 0) {
+                Spacer()
+                
+                Text("플레이리스트 만들기")
+                    .foregroundStyle(Color.mainWhite)
+                    .font(.callout)
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(Color.mainBlack)
+                    .cornerRadius(14)
+                    .padding(.horizontal, 30)
+                    .padding(.bottom, 50)
+                    .background(Rectangle().foregroundStyle(Color.gray6))
+                    .onTapGesture {
+                        vm.createArrayForExportPlaylist(setlist: setlist, songList: artistInfo?.songList ?? [], artistName: artistInfo?.name)
+                        vm.showModal.toggle()
+                    }
+                
             }
-            showCaptureAlert = false
-            showToastMessageCapture = true
-          } label: {
-            Text("이미지 저장")
-              .frame(width: UIWidth * 0.95 * 0.5)
-              .font(.callout)
-              .fontWeight(.bold)
-              .padding(.bottom)
-          }
-          // 사진 권한 허용 거부 상태인 경우
-          .alert(isPresented: $exportViewModel.showLibrarySettingsAlert) {
-            Alert(
-              title: Text(""),
-              message: Text("사진 기능을 사용하려면 ‘사진/비디오' 접근 권한을 허용해야 합니다."),
-              primaryButton: .default(Text("취소")),
-              secondaryButton: .default(Text("설정").bold(), action: {
-                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-              }))
-          }
+            if showToastMessageAppleMusic {
+                VStack {
+                    ToastMessageView(
+                        message: "Apple Music으로 세트리스트가 옮겨지고 있어요!",
+                        subMessage: "15초 후 완료 예정",
+                        icon: "dot.radiowaves.left.and.right",
+                        color: Color.toast1
+                    )
+                    .padding(.horizontal, UIWidth * 0.075)
+                    .padding(.top, 5)
+                    Spacer()
+                }
+            }
+            
+            if showSpotifyAlert {
+                VStack {
+                    ToastMessageView(
+                        message: "Spotify로 세트리스트가 옮겨지고 있어요!",
+                        subMessage: "15초 후 완료 예정",
+                        icon: "dot.radiowaves.left.and.right",
+                        color: Color.toast1
+                    )
+                    .padding(.horizontal, UIWidth * 0.075)
+                    .padding(.top, 5)
+                    Spacer()
+                }
+            }
+            
+            if showCaptureAlert {
+                ZStack {
+                    Color.black.opacity(0.6).ignoresSafeArea()
+                    captureSetlistAlertView
+                        .padding(.bottom, 120)
+                }
+            }
+            
+            if showToastMessageCapture {
+                VStack {
+                    ToastMessageView(
+                        message: "캡쳐된 이미지를 앨범에서 확인하세요",
+                        subMessage: nil,
+                        icon: "checkmark.circle.fill",
+                        color: Color.toast1
+                    )
+                    .padding(.horizontal, UIWidth * 0.075)
+                    .padding(.top, 5)
+                    Spacer()
+                }
+            }
+            
         }
-      }
+        .sheet(isPresented: $vm.showModal) {
+            BottomModalView(setlist: setlist, artistInfo: artistInfo, exportViewModel: exportViewModel, vm: vm, showToastMessageAppleMusic: $showToastMessageAppleMusic, showCaptureALert: $showCaptureAlert, showSpotifyAlert: $showSpotifyAlert)
+                .presentationDetents([.fraction(0.4)])
+                .presentationDragIndicator(.visible)
+        }
     }
-  }
+    
+    private var captureSetlistAlertView: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12.0)
+                .frame(width: UIWidth * 0.95, height: UIHeight * 0.23)
+                .foregroundStyle(Color.white)
+            VStack {
+                Text("Bugs, FLO, genie, VIBE를 이용하시나요?")
+                    .font(.callout.bold())
+                    .padding()
+                Text("위의 뮤직앱에서는 이미지로 된 세트리스트를\n인식해 플레이리스트로 변환합니다.\n원하는 세트리스트를 이미지로 받아보세요.")
+                    .multilineTextAlignment(.center)
+                    .font(.footnote)
+                    .foregroundStyle(Color.gray)
+                Divider()
+                    .padding(.vertical, 15)
+                HStack {
+                    Button {
+                        showCaptureAlert = false
+                    } label: {
+                        Text("취소")
+                            .frame(width: UIWidth * 0.95 * 0.5)
+                            .font(.callout)
+                            .foregroundStyle(Color.black)
+                            .padding(.bottom)
+                    }
+                    Button {
+                        exportViewModel.handlePhotoExportButtonAction()
+                        if !exportViewModel.checkPhotoPermission() {
+                            takeSetlistToImage(vm.setlistSongKoreanName)
+                        }
+                        showCaptureAlert = false
+                        showToastMessageCapture = true
+                    } label: {
+                        Text("이미지 저장")
+                            .frame(width: UIWidth * 0.95 * 0.5)
+                            .font(.callout)
+                            .fontWeight(.bold)
+                            .padding(.bottom)
+                    }
+                    // 사진 권한 허용 거부 상태인 경우
+                    .alert(isPresented: $exportViewModel.showLibrarySettingsAlert) {
+                        Alert(
+                            title: Text(""),
+                            message: Text("사진 기능을 사용하려면 ‘사진/비디오' 접근 권한을 허용해야 합니다."),
+                            primaryButton: .default(Text("취소")),
+                            secondaryButton: .default(Text("설정").bold(), action: {
+                                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                            }))
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Projects/Feature/Scenes/SummarizedSetlistInfoView.swift
+++ b/Projects/Feature/Scenes/SummarizedSetlistInfoView.swift
@@ -80,7 +80,7 @@ struct SummarizedSetlistInfoView: View {
                 Text(info.title.isEmpty ? "\(info.artistInfo.name)의 Setlist" : info.title)
                     .foregroundStyle(Color.mainBlack)
                     .font(.callout)
-                    .padding(5)
+                    .padding(.horizontal, 5)
                 Text(info.venue)
                     .fontWeight(.regular)
                     .foregroundStyle(Color.gray)

--- a/Tuist/ProjectDescriptionHelpers/Dependency+Spm.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency+Spm.swift
@@ -12,7 +12,7 @@ public extension TargetDependency {
 }
 
 public extension Package {
-  static let Marquee = Package.remote(url: "https://github.com/SwiftUIKit/Marquee.git", requirement: .upToNextMajor(from: "0.3.0"))
+    static let MarqueeText = Package.remote(url: "https://github.com/joekndy/MarqueeText.git", requirement: .branch("master"))
   static let SpotifyAPI = Package.remote(url: "https://github.com/Peter-Schorn/SpotifyAPI.git", requirement: .upToNextMajor(from: "3.0.0"))
   static let KeychainAccess = Package.remote(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", requirement: .upToNextMajor(from: "4.2.2"))
   static let Firebase = Package.remote(url: "https://github.com/firebase/firebase-ios-sdk.git", requirement: .upToNextMajor(from: "10.17.0"))
@@ -20,7 +20,7 @@ public extension Package {
 
 public extension TargetDependency.SPM {
   static let Firebase = TargetDependency.package(product: "FirebaseAnalytics")
-  static let Marquee = TargetDependency.package(product: "Marquee")
+  static let MarqueeText = TargetDependency.package(product: "MarqueeText")
   static let SpotifyAPI = TargetDependency.package(product: "SpotifyAPI")
   static let KeychainAccess = TargetDependency.package(product: "KeychainAccess")
 }


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #235 

👷 **작업한 내용**
- 메인뷰 수정 및 QA 내용 반영(아티스트 이미지, 아티스트 이름, 찜한 아티스트 전반적인 수정)
- 애플뮤직 속도 개선(2분 -> 15초)
- 애플뮤직 팝업 추가

## 🚨 참고 사항
- @Ko-HyeJi 아티스트뷰의 Marquee 제가 수정했습니다
- 저희 지금 앱 번들 ID @Ko-HyeJi  계정으로 등록되어 있다면 개발자 계정에서 MusicKit 추가 부탁드려용 (이거 추가 안된 번들ID는 애플뮤직 테스트할 때 안될겁니다)
- 세트리스트 뷰로 네비게이션 구현 못함.. 왜 자꾸 네비게이션 걸면 앱이 꺼지는지 모르겠어요ㅠ 도와줄분 구함

## 📸 스크린샷

https://github.com/user-attachments/assets/9b05bcea-4056-4c2d-84f4-be8812c9dcc8


## 📟 관련 이슈
- Resolved: #235 
